### PR TITLE
fix auth CORS issues

### DIFF
--- a/src/configurations/config-loader.ts
+++ b/src/configurations/config-loader.ts
@@ -55,6 +55,7 @@ interface BetterAuthConfig {
     };
   };
   basePath: string;
+  trustedOrigins: string[];
   emailAndPassword: {
     enabled: boolean;
     requireEmailVerification: boolean;
@@ -146,6 +147,7 @@ export const betterAuthConfig: BetterAuthConfig = {
     },
   },
   basePath: '/api/auth',
+  trustedOrigins: ['http://localhost:5173'],
   emailAndPassword: {
     enabled: true,
     requireEmailVerification: false,


### PR DESCRIPTION
Allow frontend running on http://localhost:5173 to make authenticated requests to Better Auth backend without triggering CORS errors.
